### PR TITLE
fix: set explicit max_pool_connections on boto3 S3 client (closes #6)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.3 (unreleased)
+
+- Fix: boto3 S3 client is now created with an explicit
+  `max_pool_connections` via `botocore.Config` (default 50, overridable
+  via `PGTHUMBOR_S3_MAX_POOL_CONNECTIONS`).  The boto3 default of 10
+  caused urllib3 pool-full warnings and connection churn under normal
+  Thumbor load (30 thumbnails per listing page times active visitors),
+  which in turn correlated with intermittent Thumbor 400s on aaf-6
+  prod.  50 covers `asyncio.to_thread`'s default executor
+  (`min(32, cpu+4)`) plus headroom.
+  Fixes [#6](https://github.com/bluedynamics/zodb-pgjsonb-thumborblobloader/issues/6).
+
 ## 0.4.2 (2026-04-02)
 
 - Fix: S3 loader now reads `PGTHUMBOR_S3_ACCESS_KEY` and `PGTHUMBOR_S3_SECRET_KEY`

--- a/src/zodb_pgjsonb_thumborblobloader/s3.py
+++ b/src/zodb_pgjsonb_thumborblobloader/s3.py
@@ -6,6 +6,7 @@ since boto3 does not natively support async.
 
 from __future__ import annotations
 
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 import asyncio
@@ -14,6 +15,13 @@ import os
 
 
 logger = logging.getLogger(__name__)
+
+# boto3's default urllib3 max_pool_connections is 10 — too low for
+# concurrent Thumbor image loads (30 thumbnails per listing page times
+# active visitors easily exceeds it, causing connection discard/reopen
+# churn and handshake-failure-induced 400s).  50 covers
+# asyncio.to_thread's default executor (min(32, cpu+4)) plus headroom.
+DEFAULT_MAX_POOL_CONNECTIONS = 50
 
 _s3_client = None
 _s3_config: tuple[str, str, str] | None = None
@@ -28,7 +36,15 @@ def _get_s3_client(bucket: str, region: str, endpoint: str = ""):
 
     import boto3
 
-    kwargs: dict = {"region_name": region}
+    max_pool = int(
+        os.environ.get(
+            "PGTHUMBOR_S3_MAX_POOL_CONNECTIONS", str(DEFAULT_MAX_POOL_CONNECTIONS)
+        )
+    )
+    kwargs: dict = {
+        "region_name": region,
+        "config": Config(max_pool_connections=max_pool),
+    }
     if endpoint:
         kwargs["endpoint_url"] = endpoint
     access_key = os.environ.get("PGTHUMBOR_S3_ACCESS_KEY", "")

--- a/tests/test_loader_s3.py
+++ b/tests/test_loader_s3.py
@@ -30,6 +30,34 @@ def _reset_s3_client():
     s3_mod._s3_config = None
 
 
+class TestS3ClientConfig:
+    """Verify the boto3 client is created with an explicit max_pool_connections."""
+
+    def test_default_max_pool_connections(self, monkeypatch):
+        from unittest.mock import patch
+        from zodb_pgjsonb_thumborblobloader import s3 as s3_mod
+
+        monkeypatch.delenv("PGTHUMBOR_S3_MAX_POOL_CONNECTIONS", raising=False)
+
+        with patch("boto3.client") as mock_client:
+            s3_mod._get_s3_client("bucket", "us-east-1")
+
+        kwargs = mock_client.call_args.kwargs
+        assert kwargs["config"].max_pool_connections == 50
+
+    def test_env_override_max_pool_connections(self, monkeypatch):
+        from unittest.mock import patch
+        from zodb_pgjsonb_thumborblobloader import s3 as s3_mod
+
+        monkeypatch.setenv("PGTHUMBOR_S3_MAX_POOL_CONNECTIONS", "128")
+
+        with patch("boto3.client") as mock_client:
+            s3_mod._get_s3_client("bucket", "us-east-1")
+
+        kwargs = mock_client.call_args.kwargs
+        assert kwargs["config"].max_pool_connections == 128
+
+
 class TestLoadS3Blob:
     """Test loading blobs from S3 via s3_key."""
 


### PR DESCRIPTION
## Summary

- Pass a `botocore.Config` with `max_pool_connections=50` (env-var overridable) when constructing the boto3 S3 client.
- Closes [#6](https://github.com/bluedynamics/zodb-pgjsonb-thumborblobloader/issues/6) — pool-full warnings and connection churn on aaf-6 prod under normal Thumbor load.

## Why this change

boto3's default `max_pool_connections` is `10`. Under typical Thumbor load (30 thumbnails per listing page × active visitors), the urllib3 pool saturates immediately and overflow requests get connection-discard-then-fresh-handshake churn. On aaf-6 prod this produced the observed `urllib3.connectionpool: Connection pool is full, discarding connection` warnings and correlates with intermittent Thumbor 400s from the downstream handshake failures.

50 is a reasonable default: covers `asyncio.to_thread`'s default executor (`min(32, cpu+4)` — i.e. 8–32 threads depending on host) plus headroom for reopen churn. Env-var override (`PGTHUMBOR_S3_MAX_POOL_CONNECTIONS`) keeps it tunable per deployment.

## Behaviour matrix

| Env var | Effect |
|---|---|
| unset (default) | `max_pool_connections=50` |
| `PGTHUMBOR_S3_MAX_POOL_CONNECTIONS=128` | `max_pool_connections=128` |

## Scope limitations (out of scope, candidates for a follow-up)

- **Timeouts**: `Config` does not override `connect_timeout`/`read_timeout`; boto3 defaults of 60s/60s remain. A hanging S3 connection still blocks a worker for up to 60s. If the pool fix alone doesn't eliminate the residual 400s, tightening to ~5s/30s via the same `Config` is the next lever.
- **Cache key**: `_get_s3_client` caches by `(bucket, region, endpoint)`. The env var is read once per client construction (first call wins); not worth including in the cache key since it won't vary per process.

## Test plan

- [x] New test `test_default_max_pool_connections`: mocks `boto3.client`, asserts `kwargs["config"].max_pool_connections == 50` with the env var unset.
- [x] New test `test_env_override_max_pool_connections`: env var `=128` → asserts `max_pool_connections == 128`.
- [x] Existing S3/moto/integration tests unchanged and passing (80/80).
- [ ] Production verification on aaf-6: `urllib3.connectionpool: Connection pool is full` warnings should disappear; Thumbor 400 rate should drop.

## One small factual note

Issue #6 mentions `asyncio.to_thread`'s default executor has "40 threads". Python 3.8+ actually defaults to `min(32, os.cpu_count()+4)` (so 8–32 in practice). Doesn't affect the recommendation — 50 still covers it with room — but the comment in the source now uses the accurate figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)